### PR TITLE
update SMART AM40 dts

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3399-am40.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3399-am40.dts
@@ -18,6 +18,11 @@
 		ethernet0 = &gmac;
 		mmc0 = &sdhci;
 		mmc1 = &sdmmc;
+		/*
+		 * The rk808 circuit design on this board does not have the ability to maintain real-time time after a power outage.
+		 * Registering rk808 as rtc99 (most kernel configurations read time from rtc0) can prevent the kernel from reading the time (2013) from rk808 during startup.
+		 */
+		rtc99 = &rk808;
 	};
 
 	chosen {
@@ -174,6 +179,8 @@
 
 	virtual_pd: virtual-pd {
 		compatible = "linux,extcon-usbc-virtual-pd";
+		pinctrl-names = "default";
+		pinctrl-0 = <&dp_hpd>;
 		det-gpios = <&gpio4 RK_PD1 GPIO_ACTIVE_LOW>;
 		vpd-data-role = "display-port";
 		vpd-super-speed;
@@ -527,7 +534,7 @@
 	};
 
 	display {
-		dp-hpd {
+		dp_hpd: dp-hpd {
 			rockchip,pins = <4 RK_PD1 RK_FUNC_GPIO &pcfg_input_pull_up>;
 		};
 


### PR DESCRIPTION
主要有两点更新：

1.AM40无额外的RTC芯片，但板子上有一个纽扣电池，便猜测使用RK808内部集成的RTC模块，但实测RK808的RTC不起作用，在完全断电并上电后，丢失了实时时间（实测纽扣电池有电）。所以该板子的设计是无RTC功能，从[原系统的DTS](https://github.com/retro98boy/smart-am40-linux/blob/master/devicetree/dump/origin.dts)禁用RK808 RTC也能验证这一点：

```
            vddio-supply = <0x00000039>;
            linux,phandle = <0x000000d3>;
            phandle = <0x000000d3>;
            rtc {
                status = "disabled";
            };
            regulators {
```

目前主线DTS没法像BSP DTS这样禁用RK808的RTC，该补丁将RK808注册成rtc99，这样内核在启动时不会从其中读取没用的时间。另外一个办法是不编译rtc_rk808模块，或者将rtc_rk808加到黑名单中，但这可能会影响其它设备且需要额外的操作

2.在virtual-pd节点下增加对应的dp_hpd pinctrl属性，确保dp_hpd引脚的复用生效