### PR TITLE
cainiao-cniot-core dts update

### DIFF
--- a/arch/arm64/boot/dts/amlogic/meson-g12b-a311d-cainiao-cniot-core.dts
+++ b/arch/arm64/boot/dts/amlogic/meson-g12b-a311d-cainiao-cniot-core.dts
@@ -11,6 +11,7 @@
 #include "meson-g12b-a311d.dtsi"
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/gpio/meson-g12a-gpio.h>
+#include <dt-bindings/sound/meson-g12a-toacodec.h>
 #include <dt-bindings/sound/meson-g12a-tohdmitx.h>
 
 / {
@@ -81,9 +82,17 @@
 		};
 	};
 
+	ht6872: ht6872 {
+		compatible = "simple-audio-amplifier";
+		enable-gpios = <&gpio_ao GPIOAO_2 GPIO_ACTIVE_HIGH>;
+		VCC-supply = <&vdd_amp>;
+		sound-name-prefix = "HT6872";
+		status = "okay";
+	};
+
 	sdio_pwrseq: sdio-pwrseq {
 		compatible = "mmc-pwrseq-simple";
-		reset-gpios = <&gpio GPIOX_7 GPIO_ACTIVE_LOW>;
+		reset-gpios = <&gpio GPIOX_6 GPIO_ACTIVE_LOW>;
 		clocks = <&wifi32k>;
 		clock-names = "ext_clock";
 	};
@@ -167,14 +176,50 @@
 		vin-supply = <&dc_in>;
 	};
 
+	/*
+	 * The Type-C port on the host is switched with the four USB contacts on the side of the host via GPIOA_14.
+	 * Since the Type-C port on the host is either used for power supply or blocked by the dock,
+	 * switching USB 2.0 access to the four contacts on the side of the host is a better choice.
+	 * To use the Type-C port for data transmission,
+	 * you only need to set GPIOA_14 in the node below to a high level.
+	 */
+	usb_switch: regulator-usb-switch {
+		compatible = "regulator-fixed";
+		enable-active-low;
+		gpio = <&gpio GPIOA_14 GPIO_ACTIVE_LOW>;
+		regulator-name = "usb_switch";
+		regulator-always-on;
+		regulator-boot-on;
+		vin-supply = <&dc_in>;
+	};
+
+	vdd_amp: regulator-vdd-amp {
+		compatible = "regulator-fixed";
+		enable-active-high;
+		gpio = <&gpio GPIOH_7 GPIO_ACTIVE_HIGH>;
+		regulator-name = "vdd_amp";
+		regulator-always-on;
+		regulator-boot-on;
+		vin-supply = <&dc_in>;
+	};
+
 	sound {
 		compatible = "amlogic,axg-sound-card";
-		model = "CNIoT-CORE";
-		audio-aux-devs = <&tdmout_b>;
-		audio-routing = "TDMOUT_B IN 0", "FRDDR_A OUT 1",
+		model = "cainiao-cniot-core";
+		audio-widgets = "Speaker", "Internal Speaker";
+		audio-aux-devs = <&tdmout_a>, <&tdmout_b>, <&ht6872>;
+		audio-routing = "TDMOUT_A IN 0", "FRDDR_A OUT 0",
+				"TDMOUT_A IN 1", "FRDDR_B OUT 0",
+				"TDMOUT_A IN 2", "FRDDR_C OUT 0",
+				"TDM_A Playback", "TDMOUT_A OUT",
+				"TDMOUT_B IN 0", "FRDDR_A OUT 1",
 				"TDMOUT_B IN 1", "FRDDR_B OUT 1",
 				"TDMOUT_B IN 2", "FRDDR_C OUT 1",
-				"TDM_B Playback", "TDMOUT_B OUT";
+				"TDM_B Playback", "TDMOUT_B OUT",
+				"HT6872 INL", "ACODEC LOLP",
+				"HT6872 INR", "ACODEC LORP",
+				"Internal Speaker", "HT6872 OUTL",
+				"Internal Speaker", "HT6872 OUTR";
 
 		clocks = <&clkc CLKID_MPLL2>,
 			 <&clkc CLKID_MPLL0>,
@@ -202,6 +247,25 @@
 
 		/* 8ch hdmi interface */
 		dai-link-3 {
+			sound-dai = <&tdmif_a>;
+			dai-format = "i2s";
+			dai-tdm-slot-tx-mask-0 = <1 1>;
+			dai-tdm-slot-tx-mask-1 = <1 1>;
+			dai-tdm-slot-tx-mask-2 = <1 1>;
+			dai-tdm-slot-tx-mask-3 = <1 1>;
+			mclk-fs = <256>;
+
+			codec-0 {
+				sound-dai = <&tohdmitx TOHDMITX_I2S_IN_A>;
+			};
+
+			codec-1 {
+				sound-dai = <&toacodec TOACODEC_IN_A>;
+			};
+		};
+
+		/* 8ch hdmi interface */
+		dai-link-4 {
 			sound-dai = <&tdmif_b>;
 			dai-format = "i2s";
 			dai-tdm-slot-tx-mask-0 = <1 1>;
@@ -210,20 +274,38 @@
 			dai-tdm-slot-tx-mask-3 = <1 1>;
 			mclk-fs = <256>;
 
-			codec {
+			codec-0 {
 				sound-dai = <&tohdmitx TOHDMITX_I2S_IN_B>;
+			};
+
+			codec-1 {
+				sound-dai = <&toacodec TOACODEC_IN_B>;
 			};
 		};
 
 		/* hdmi glue */
-		dai-link-4 {
+		dai-link-5 {
 			sound-dai = <&tohdmitx TOHDMITX_I2S_OUT>;
 
 			codec {
 				sound-dai = <&hdmi_tx>;
 			};
 		};
+
+		/* acodec glue */
+		dai-link-6 {
+			sound-dai = <&toacodec TOACODEC_OUT>;
+
+			codec {
+				sound-dai = <&acodec>;
+			};
+		};
 	};
+};
+
+&acodec {
+	AVDD-supply = <&vddao_1v8>;
+	status = "okay";
 };
 
 &arb {
@@ -305,13 +387,12 @@
 	pinctrl-names = "default";
 	status = "okay";
 	phy-mode = "rgmii";
-	phy-handle = <&external_phy>;
+	phy-handle = <&rtl8211f>;
 	amlogic,tx-delay-ns = <2>;
 };
 
 &ext_mdio {
-	external_phy: ethernet-phy@0 {
-		/* Realtek RTL8211F (0x001cc916) */
+	rtl8211f: rtl8211f@0 {
 		reg = <0>;
 		max-speed = <1000>;
 
@@ -321,7 +402,7 @@
 
 		interrupt-parent = <&gpio_intc>;
 		/* MAC_INTR on GPIOZ_14 */
-		interrupts = <IRQID_GPIOZ_14 IRQ_TYPE_LEVEL_LOW>; /* not sure */
+		interrupts = <IRQID_GPIOZ_14 IRQ_TYPE_LEVEL_LOW>; /* tested by voltmeter */
 	};
 };
 
@@ -347,18 +428,6 @@
 	hdmi_tx_tmds_out: endpoint {
 		remote-endpoint = <&hdmi_connector_in>;
 	};
-};
-
-&i2c2 {
-	status = "okay";
-	pinctrl-0 = <&i2c2_sda_z_pins>, <&i2c2_sck_z_pins>;
-	pinctrl-names = "default";
-};
-
-&i2c3 {
-	status = "okay";
-	pinctrl-0 = <&i2c3_sda_a_pins>, <&i2c3_sck_a_pins>;
-	pinctrl-names = "default";
 };
 
 &npu {
@@ -408,7 +477,6 @@
 
 	bus-width = <4>;
 	max-frequency = <100000000>;
-	/* irq pin: GPIOX_8 active low */
 	cap-sdio-irq;
 	cap-sd-highspeed;
 	non-removable;
@@ -421,6 +489,11 @@
 
 	rtl8822cs: wifi@1 {
 		reg = <1>;
+		/*
+		 * tested by voltmeter
+		 * WL_REG_ON GPIOX_6
+		 * WL_WAKE_HOST GPIOX_5
+		 */
 	};
 };
 
@@ -442,9 +515,20 @@
 	vqmmc-supply = <&vddao_1v8>;
 };
 
+/*
+ * GPIOH_4 is connected to 6 WS2812 LEDs.
+ * Reusing GPIOH_4 as SPI MOSI to control the WS2812 offers superior performance compared to the GPIO method.
+ */
+&spicc1_pins {
+	mux {
+		groups = "spi1_mosi";
+	};
+};
+
+/* Controlling WS2812 LEDs via spidev in user space. */
 &spicc1 {
 	status = "okay";
-	pinctrl-0 = <&spicc1_pins>, <&spicc1_ss0_pins>;
+	pinctrl-0 = <&spicc1_pins>;
 	pinctrl-names = "default";
 
 	spidev@0 {
@@ -454,11 +538,23 @@
 	};
 };
 
+&tdmif_a {
+	status = "okay";
+};
+
 &tdmif_b {
 	status = "okay";
 };
 
+&tdmout_a {
+	status = "okay";
+};
+
 &tdmout_b {
+	status = "okay";
+};
+
+&toacodec {
 	status = "okay";
 };
 
@@ -474,9 +570,9 @@
 
 	bluetooth {
 		compatible = "realtek,rtl8822cs-bt";
-		enable-gpios = <&gpio GPIOX_17 GPIO_ACTIVE_HIGH>; /* not sure */
-		host-wake-gpios = <&gpio GPIOX_19 GPIO_ACTIVE_HIGH>; /* not sure */
-		device-wake-gpios = <&gpio GPIOX_18 GPIO_ACTIVE_HIGH>; /* not sure */
+		enable-gpios = <&gpio GPIOX_17 GPIO_ACTIVE_HIGH>; /* tested by voltmeter */
+		host-wake-gpios = <&gpio GPIOX_18 GPIO_ACTIVE_HIGH>; /* tested by voltmeter */
+		device-wake-gpios = <&gpio GPIOX_19 GPIO_ACTIVE_HIGH>; /* tested by voltmeter */
 	};
 };
 
@@ -491,7 +587,7 @@
 };
 
 &usb2_phy1 {
-	phy-supply = <&amp_power>;
+	phy-supply = <&usb_switch>;
 };
 
 &usb3_pcie_phy {


### PR DESCRIPTION
- 支持内部扬声器，用户层音频路由设置可参考[此处](https://github.com/retro98boy/cainiao-cniot-core-linux#%E9%9F%B3%E9%A2%91)
- 支持侧边的呼吸灯，用户层的demo见[此处](https://github.com/retro98boy/cainiao-cniot-core-linux/tree/main/breathing-light)
- 默认使能侧边的USB触点