### PR TITLE
arm64: dts: allwinner: h616: fix emac1 to use stmmac driver

### DIFF
--- a/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
+++ b/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
@@ -858,24 +858,19 @@
 		};
 
 		emac1: ethernet@5030000 {
-			compatible = "allwinner,sunxi-gmac";
-			reg = <0x05030000 0x10000>,
-				<0x03000034 0x4>;
-			reg-names = "gmac1_reg","ephy_reg";
+			compatible = "allwinner,sun50i-h616-emac";
+			syscon = <&syscon 1>;
+			reg = <0x05030000 0x10000>;
 			interrupts = <GIC_SPI 15 IRQ_TYPE_LEVEL_HIGH>;
-			interrupt-names = "gmacirq";
+			interrupt-names = "macirq";
 			resets = <&ccu RST_BUS_EMAC1>;
 			reset-names = "stmmaceth";
-			clocks = <&ccu CLK_BUS_EMAC1>,<&ccu CLK_EMAC_25M>;
-			clock-names = "bus-emac1","emac-25m";
-			pinctrl-0 = <&rmii_pins>;
-			pinctrl-names = "default";
-			tx-delay = <7>;
-			rx-delay = <31>;
+			clocks = <&ccu CLK_BUS_EMAC1>;
+			clock-names = "stmmaceth";
 			status = "disabled";
 
 			mdio1: mdio {
-				compatible = "ethernet-phy-ieee802.3-c22";
+				compatible = "snps,dwmac-mdio";
 				#address-cells = <1>;
 				#size-cells = <0>;
 			};


### PR DESCRIPTION
revert: https://github.com/unifreq/linux-6.12.y/commit/107fc0767f88f391aaead152f3f76fe92efc8fbc

The emac1 node was using the BSP-style compatible "allwinner,sunxi-gmac"
which has no corresponding driver in the kernel tree. Change it to use
the stmmac/dwmac-sun8i driver (same as emac0) with the proper compatible
strings and bindings.

The dwmac-sun8i driver already supports H616 via the compatible
"allwinner,sun50i-h616-emac" added in the driver, and the syscon index
mechanism allows addressing the second EMAC clock register at offset +4.

This change:
- Replaces BSP "allwinner,sunxi-gmac" with stmmac-compatible strings
- Fixes reg to use only the EMAC register block (syscon handles clock reg)
- Removes BSP-specific reg-names, clock-names, pinctrl, tx/rx-delay
  (these should be set in board-level DTS files)
- Fixes mdio compatible from "ethernet-phy-ieee802.3-c22" to
  "snps,dwmac-mdio" (matching stmmac driver expectations)
- Adds syscon with index 1 to select the second EMAC clock register