### PR TITLE
arm64: dts: allwinner: sun50i-h6: add AC200 EPHY nodes and enable Eth…

### DIFF
--- a/arch/arm64/boot/dts/allwinner/sun50i-h6-tanix.dtsi
+++ b/arch/arm64/boot/dts/allwinner/sun50i-h6-tanix.dtsi
@@ -10,6 +10,7 @@
 
 / {
 	aliases {
+		ethernet0 = &emac;
 		serial0 = &uart0;
 	};
 
@@ -88,6 +89,16 @@
 	cpu-supply = <&reg_vdd_cpu_gpu>;
 };
 
+&ac200_ephy_ctl {
+	x-powers,led-polarity = <GPIO_ACTIVE_HIGH>;
+	phy-address = <1>;
+	status = "okay";
+};
+
+&ac200_pwm_clk {
+	status = "okay";
+};
+
 &de {
 	status = "okay";
 };
@@ -104,6 +115,14 @@
 	status = "okay";
 };
 
+&emac {
+	pinctrl-names = "default";
+	pinctrl-0 = <&ext_rmii_pins>;
+	phy-mode = "rmii";
+	phy-handle = <&ext_rmii_phy>;
+	status = "okay";
+};
+
 &gpu {
 	mali-supply = <&reg_vdd_cpu_gpu>;
 	status = "okay";
@@ -116,6 +135,21 @@
 &hdmi_out {
 	hdmi_out_con: endpoint {
 		remote-endpoint = <&hdmi_con_in>;
+	};
+};
+
+&i2c3 {
+	status = "okay";
+};
+
+&mdio {
+	ext_rmii_phy: ethernet-phy@1 {
+		compatible = "ethernet-phy-id0044.1400",
+			     "ethernet-phy-ieee802.3-c22";
+		reg = <1>;
+		resets = <&ac200_ephy_ctl>;
+		reset-names = "phy";
+		clocks = <&ac200_ephy_ctl>;
 	};
 };
 
@@ -159,6 +193,10 @@
 	vcc-pc-supply = <&reg_vcc1v8>;
 	vcc-pd-supply = <&reg_vcc3v3>;
 	vcc-pg-supply = <&reg_vcc1v8>;
+};
+
+&pwm {
+	status = "okay";
 };
 
 &r_ir {

--- a/arch/arm64/boot/dts/allwinner/sun50i-h6.dtsi
+++ b/arch/arm64/boot/dts/allwinner/sun50i-h6.dtsi
@@ -17,6 +17,16 @@
 	#address-cells = <1>;
 	#size-cells = <1>;
 
+	ac200_pwm_clk: ac200_clk {
+		compatible = "pwm-clock";
+		#clock-cells = <0>;
+		clock-frequency = <24000000>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&pwm1_pin>;
+		pwms = <&pwm 1 42 0>;
+		status = "disabled";
+	};
+
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -318,6 +328,14 @@
 			cpu_speed_grade: cpu-speed-grade@1c {
 				reg = <0x1c 0x4>;
 			};
+
+			ephy_calib: ephy_calib@2c {
+				reg = <0x2c 0x2>;
+			};
+
+			ac200_bg: ac200_bg@30 {
+				reg = <0x30 0x2>;
+			};
 		};
 
 		timer@3009000 {
@@ -372,6 +390,13 @@
 				drive-strength = <40>;
 			};
 
+			ext_rmii_pins: rmii_pins {
+				pins = "PA0", "PA1", "PA2", "PA3", "PA4",
+				       "PA5", "PA6", "PA7", "PA8", "PA9";
+				function = "emac";
+				drive-strength = <40>;
+			};
+
 			hdmi_pins: hdmi-pins {
 				pins = "PH8", "PH9", "PH10";
 				function = "hdmi";
@@ -390,6 +415,12 @@
 			i2c2_pins: i2c2-pins {
 				pins = "PD23", "PD24";
 				function = "i2c2";
+			};
+
+			i2c3_pins: i2c3-pins {
+				pins = "PB17", "PB18";
+				function = "i2c3";
+				bias-pull-up;
 			};
 
 			mmc0_pins: mmc0-pins {
@@ -418,13 +449,16 @@
 				bias-pull-up;
 			};
 
+			pwm1_pin: pwm1-pin {
+				pins = "PB19";
+				function = "pwm1";
+			};
+
 			/omit-if-no-ref/
 			spi0_pins: spi0-pins {
 				pins = "PC0", "PC2", "PC3";
 				function = "spi0";
 			};
-
-			/* pin shared with MMC2-CMD (eMMC) */
 			/omit-if-no-ref/
 			spi0_cs_pin: spi0-cs-pin {
 				pins = "PC5";
@@ -620,6 +654,43 @@
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
+		};
+
+		i2c3: i2c@5002c00 {
+			compatible = "allwinner,sun50i-h6-i2c",
+				     "allwinner,sun6i-a31-i2c";
+			reg = <0x05002c00 0x400>;
+			interrupts = <GIC_SPI 7 IRQ_TYPE_LEVEL_HIGH>;
+			clocks = <&ccu CLK_BUS_I2C3>;
+			resets = <&ccu RST_BUS_I2C3>;
+			pinctrl-names = "default";
+			pinctrl-0 = <&i2c3_pins>;
+			clock-frequency = <100000>;
+			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			ac200: mfd@10 {
+				compatible = "x-powers,ac200";
+				reg = <0x10>;
+				clocks = <&ac200_pwm_clk>;
+				interrupt-parent = <&pio>;
+				interrupts = <1 20 IRQ_TYPE_LEVEL_LOW>;
+				interrupt-controller;
+				#interrupt-cells = <1>;
+				nvmem-cells = <&ac200_bg>;
+				nvmem-cell-names = "bandgap";
+
+				ac200_ephy_ctl: syscon {
+					compatible = "x-powers,ac200-ephy-ctl";
+					nvmem-cells = <&ephy_calib>;
+					nvmem-cell-names = "calibration";
+					#clock-cells = <0>;
+					#reset-cells = <0>;
+					phy-mode = "rmii";
+					status = "disabled";
+				};
+			};
 		};
 
 		spi0: spi@5010000 {

--- a/arch/arm64/boot/dts/rockchip/rk3399-xiaobao.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3399-xiaobao.dts
@@ -545,6 +545,10 @@
 	num-lanes = <4>;
 	pinctrl-names = "default";
 	pinctrl-0 = <&pcie_clkreqnb_cpm &fn8274_en_h>;
+	/* Gen2 speed; 0x83000000 = 64-bit prefetchable memory to fix SATA DMA issue */
+	max-link-speed = <2>;
+	ranges = <0x83000000 0x0 0xfa000000 0x0 0xfa000000 0x0 0x1e00000>,
+		 <0x81000000 0x0 0xfbe00000 0x0 0xfbe00000 0x0 0x100000>;
 	status = "okay";
 };
 


### PR DESCRIPTION
Copy from:

https://github.com/armbian/build/blob/main/patch/kernel/archive/sunxi-6.12/patches.armbian/arm64-dts-allwinner-h6-Add-AC200-EPHY-nodes.patch

https://github.com/armbian/build/blob/main/patch/kernel/archive/sunxi-6.12/patches.armbian/arm64-dts-allwinner-h6-tanix-enable-Ethernet.patch